### PR TITLE
Support GHC 8.4.1 with the Semigroup as a supertype of Monoid proposal

### DIFF
--- a/shake-language-c.cabal
+++ b/shake-language-c.cabal
@@ -64,6 +64,8 @@ Library
     , shake >= 0.16
     , split
     , unordered-containers
+  if impl(ghc < 8.0)
+    Build-Depends: semigroups >= 0.18
 
 test-suite doctests
   type:           exitcode-stdio-1.0

--- a/src/Development/Shake/Language/C/BuildFlags.hs
+++ b/src/Development/Shake/Language/C/BuildFlags.hs
@@ -57,6 +57,7 @@ import           Data.Default.Class (Default(..))
 import           Data.List
 import           Data.List.Split
 import           Data.Maybe
+import           Data.Semigroup
 import           Development.Shake.Language.C.Language (Language(..))
 import           Development.Shake.Language.C.Label
 import           Development.Shake.Language.C.Util
@@ -142,9 +143,8 @@ defaultBuildFlags =
 instance Default BuildFlags where
   def = defaultBuildFlags
 
-instance Monoid BuildFlags where
-  mempty = defaultBuildFlags
-  a `mappend` b =
+instance Semigroup BuildFlags where
+  a <> b =
       append systemIncludes    (get systemIncludes a)
     . append userIncludes      (get userIncludes a)
     . append defines           (get defines a)
@@ -156,6 +156,10 @@ instance Monoid BuildFlags where
     . append localLibraries    (get localLibraries a)
     . append archiverFlags     (get archiverFlags a)
     $ b
+
+instance Monoid BuildFlags where
+  mempty = defaultBuildFlags
+  mappend = (<>)
 
 -- | Construct preprocessor flags from the 'defines' field of 'BuildFlags'.
 defineFlags :: BuildFlags -> [String]


### PR DESCRIPTION
Without this the library fails to build with GHC 8.4.1.