### PR TITLE
pkgConfig ignores some cflags

### DIFF
--- a/src/Development/Shake/Language/C/PkgConfig.hs
+++ b/src/Development/Shake/Language/C/PkgConfig.hs
@@ -54,7 +54,7 @@ parseCflags [] = id
 parseCflags (x:xs)
   | isPrefixOf "-I" x = parseCflags xs . append systemIncludes [drop 2 x]
   | isPrefixOf "-i" x = parseCflags xs . append userIncludes [drop 2 x]
-  | otherwise = append compilerFlags [(Nothing, [x])]
+  | otherwise = parseCflags xs . append compilerFlags [(Nothing, [x])]
 
 parseLibs :: [String] -> (BuildFlags -> BuildFlags)
 parseLibs [] = id


### PR DESCRIPTION
I was trying out shake-language-c on several different platforms and I encountered a bug where the parseCflags function would stop parsing the cflags after the first flag that isn't -i or -I.  I've fixed it so that it works the same was parseLibs.