### PR TITLE
added a "None" OS

### DIFF
--- a/src/Development/Shake/Language/C/Target.hs
+++ b/src/Development/Shake/Language/C/Target.hs
@@ -37,6 +37,7 @@ data OS =
   | OSX     -- ^ Apple Mac OSX and iOS
   | Pepper  -- ^ Google Portable Native Client (PNaCl)
   | Windows -- ^ Microsoft Windows
+  | None    -- ^ No OS (bare metal)
   deriving (Eq, Ord, Show)
 
 -- | Target platform.


### PR DESCRIPTION
It doesn't seem the OS type actually impacts much, so maybe this isn't directly useful, but I'm using shake-language-c for an embedded project that has no OS and it seemed there should be a "None" OS.