### PR TITLE
added an "Asm" language to allow customizing build flags for asm sources

### DIFF
--- a/src/Development/Shake/Language/C/Language.hs
+++ b/src/Development/Shake/Language/C/Language.hs
@@ -30,6 +30,7 @@ data Language =
   | Cpp     -- ^ C++
   | ObjC    -- ^ Objective-C
   | ObjCpp  -- ^ Objective-C with C++ (Apple extension)
+  | Asm     -- ^ Assembly
   deriving (Enum, Eq, Show)
 
 -- | Default mapping from file extension to source language.
@@ -39,6 +40,7 @@ defaultLanguageMap = concatMap f [
   , (Cpp, [".cc", ".CC", ".cpp", ".CPP", ".C", ".cxx", ".CXX"])
   , (ObjC, [".m"])
   , (ObjCpp, [".mm", ".M"])
+  , (Asm, [".s", ".S"])
   ]
   where f (lang, exts) = map (\ext -> (ext, lang)) exts
 


### PR DESCRIPTION
As mentioned in my other PR, I'm building a bare-metal project using shake-language-c, and I found it useful to add an Asm language, so I can configure different build flags for asm files.