### PR TITLE
linux: fix archiver when building with LLVM (clang)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, data-default-class, directory, doctest
+, fclabels, hspec, lib, process, shake, split, unordered-containers
+}:
+mkDerivation {
+  pname = "shake-language-c";
+  version = "0.13.1";
+  src = ./.;
+  libraryHaskellDepends = [
+    base data-default-class fclabels process shake split
+    unordered-containers
+  ];
+  testHaskellDepends = [ base directory doctest hspec shake ];
+  doHaddock = false;
+  doCheck = false;
+  homepage = "https://github.com/samplecount/shake-language-c";
+  description = "Utilities for cross-compiling with Shake";
+  license = lib.licenses.asl20;
+}

--- a/shake-language-c.cabal
+++ b/shake-language-c.cabal
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 Name:         shake-language-c
-Version:      0.13.0
+Version:      0.13.1
 Synopsis:     Utilities for cross-compiling with Shake
 Description:  This library provides <http://hackage.haskell.org/package/shake Shake> utilities for cross-compiling @C@, @C++@ and @ObjC@ code for various target platforms. Currently supported target platforms are Android, iOS, Linux, MacOS X, Windows\/MinGW and Google Portable Native Client (PNaCl). Supported host platforms are MacOS X, Linux and Windows.
 Category:     Development

--- a/src/Development/Shake/Language/C/Target/Linux.hs
+++ b/src/Development/Shake/Language/C/Target/Linux.hs
@@ -61,6 +61,7 @@ toolChain LLVM =
     set variant LLVM
   $ set compilerCommand "clang"
   $ set archiverCommand "ar"
+  $ set archiver platformArchiver
   $ set linkerCommand "clang++"
   $ defaultToolChain
 toolChain Generic = toolChain GCC


### PR DESCRIPTION
Add `cr` to ar when built on Linux, even if using Clang

```
Development.Shake.command_, system command failed
Command line: ar build/linux/x86_64/libHobbes.a build/linux/x86_64/libHobbes_a_obj/lib/hobbes/boot/gen/boot.C.rel.o build/linux/x86_64/libHobbes_a_obj/lib/hobbes/db/bindings.C.rel.o build/linux/x86_64/libHobbes_a_obj/lib/hobbes>
Exit code: 1
Stderr:
ar: invalid option -- '/'
```